### PR TITLE
AGDIGGER-30 - S2I build support for jenkins image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM openshift/jenkins-1-centos7
+COPY plugins.txt /opt/openshift/configuration/plugins.txt
+RUN /usr/local/bin/plugins.sh /opt/openshift/configuration/plugins.txt

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,14 @@
+# Aerogear Jenkins openshift docker image
+
+## Why another image?
+
+OpenShift Jenkins docker images use `source to image` aproach for customizing jenkins plugins and configuration. 
+We need to use it in order to make any change in jenkins configuration that would be persisted in image.
+
+For base image source code and documentation please refer to https://github.com/openshift/jenkins
+
+## Building
+
+To build install s2i build tool from: https://github.com/openshift/source-to-image/releases/tag/v1.1.3 
+
+    s2i build . openshift/jenkins-1-centos7 aerogear/jenkins-1-centos7

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,8 +2,8 @@
 
 ## Why another image?
 
-OpenShift Jenkins docker images use `source to image` aproach for customizing jenkins plugins and configuration. 
-We need to use it in order to make any change in jenkins configuration that would be persisted in image.
+OpenShift Jenkins docker images use `source to image` aproach for customizing jenkins plugins and configuration.
+We make use of the 'source to image' so that any changes made to the jenkins configuration and plugins would be persisted
 
 For base image source code and documentation please refer to https://github.com/openshift/jenkins
 

--- a/docker/configuration/configuration.xml.tpl
+++ b/docker/configuration/configuration.xml.tpl
@@ -1,0 +1,57 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <disabledAdministrativeMonitors/>
+  <version>1.651</version>
+  <numExecutors>5</numExecutors>
+  <mode>NORMAL</mode>
+  <useSecurity>true</useSecurity>
+  <authorizationStrategy class="hudson.security.GlobalMatrixAuthorizationStrategy">
+    <permission>hudson.model.Computer.Configure:admin</permission>
+    <permission>hudson.model.Computer.Delete:admin</permission>
+    <permission>hudson.model.Hudson.Administer:admin</permission>
+    <permission>hudson.model.Hudson.Read:admin</permission>
+    <permission>hudson.model.Item.Build:admin</permission>
+    <permission>hudson.model.Item.Configure:admin</permission>
+    <permission>hudson.model.Item.Create:admin</permission>
+    <permission>hudson.model.Item.Delete:admin</permission>
+    <permission>hudson.model.Item.Read:admin</permission>
+    <permission>hudson.model.Item.Workspace:admin</permission>
+    <permission>hudson.model.Run.Delete:admin</permission>
+    <permission>hudson.model.Run.Update:admin</permission>
+    <permission>hudson.model.View.Configure:admin</permission>
+    <permission>hudson.model.View.Create:admin</permission>
+    <permission>hudson.model.View.Delete:admin</permission>
+    <permission>hudson.scm.SCM.Tag:admin</permission>
+  </authorizationStrategy>
+  <securityRealm class="hudson.security.HudsonPrivateSecurityRealm">
+    <disableSignup>true</disableSignup>
+    <enableCaptcha>false</enableCaptcha>
+  </securityRealm>
+  <disableRememberMe>false</disableRememberMe>
+  <workspaceDir>${ITEM_ROOTDIR}/workspace</workspaceDir>
+  <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+  <markupFormatter class="hudson.markup.RawHtmlMarkupFormatter"/>
+  <jdks/>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+  <clouds>
+    ${KUBERNETES_CONFIG}
+  </clouds>
+  <quietPeriod>1</quietPeriod>
+  <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+  <views>
+    <hudson.model.AllView>
+      <owner class="hudson" reference="../../.."/>
+      <name>All</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties/>
+    </hudson.model.AllView>
+  </views>
+  <primaryView>All</primaryView>
+  <slaveAgentPort>${JNLP_PORT}</slaveAgentPort>
+  <label>master</label>
+  <nodeProperties/>
+  <globalNodeProperties/>
+  <noUsageStatistics>true</noUsageStatistics>
+</hudson>

--- a/docker/configuration/jobs/.nocontent
+++ b/docker/configuration/jobs/.nocontent
@@ -1,0 +1,1 @@
+Placed to remove default jobs created by openshift instance.

--- a/docker/plugins.txt
+++ b/docker/plugins.txt
@@ -1,0 +1,1 @@
+script-realm:1.5

--- a/openshift/jenkins-persistent-template.json
+++ b/openshift/jenkins-persistent-template.json
@@ -28,7 +28,7 @@
         "tls": {
           "termination": "edge",
           "insecureEdgeTerminationPolicy": "Redirect"
-        }
+          }
       }
     },
     {
@@ -61,21 +61,6 @@
         },
         "triggers": [
           {
-            "type": "ImageChange",
-            "imageChangeParams": {
-              "automatic": true,
-              "containerNames": [
-                "jenkins"
-              ],
-              "from": {
-                "kind": "ImageStreamTag",
-                "name": "${JENKINS_IMAGE_STREAM_TAG}",
-                "namespace": "${NAMESPACE}"
-              },
-              "lastTriggeredImage": ""
-            }
-          },
-          {
             "type": "ConfigChange"
           }
         ],
@@ -95,7 +80,7 @@
             "containers": [
               {
                 "name": "jenkins",
-                "image": " ",
+                "image": "${JENKINS_IMAGE}:${JENKINS_IMAGE_VERSION}",
                 "readinessProbe": {
                   "timeoutSeconds": 3,
                   "initialDelaySeconds": 3,
@@ -113,10 +98,6 @@
                     }
                 },
                 "env": [
-                  {
-                    "name": "OPENSHIFT_ENABLE_OAUTH",
-                    "value": "false"
-                  },
                   {
                     "name": "JENKINS_PASSWORD",
                     "value": "${JENKINS_PASSWORD}"
@@ -211,6 +192,7 @@
         "selector": {
           "name": "${JENKINS_SERVICE_NAME}"
         },
+        "portalIP": "",
         "type": "ClusterIP",
         "sessionAffinity": "None"
       }
@@ -239,6 +221,7 @@
          "selector": {
            "name": "${JENKINS_SERVICE_NAME}"
          },
+         "portalIP": "",
          "type": "ClusterIP",
          "sessionAffinity": "None"
        }
@@ -269,26 +252,26 @@
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
-      "value": "512Mi"
+      "value": "1Gi"
     },
     {
       "name": "VOLUME_CAPACITY",
       "displayName": "Volume Capacity",
       "description": "Volume space available for data, e.g. 512Mi, 2Gi.",
-      "value": "1Gi",
+      "value": "40Gi",
       "required": true
     },
     {
-      "name": "NAMESPACE",
-      "displayName": "Jenkins ImageStream Namespace",
-      "description": "The OpenShift Namespace where the Jenkins ImageStream resides.",
-      "value": "openshift"
+      "name": "JENKINS_IMAGE",
+      "displayName": "Jenkins docker image reference",
+      "description": "Full name of jenkins image for example ",
+      "value": "wtrocki/jenkins"
     },
     {
-      "name": "JENKINS_IMAGE_STREAM_TAG",
-      "displayName": "Jenkins ImageStreamTag",
-      "description": "Name of the ImageStreamTag to be used for the Jenkins image.",
-      "value": "jenkins:latest"
+      "name": "JENKINS_IMAGE_VERSION",
+      "displayName": "Jenkins image version",
+      "description": "Jenkins image version",
+      "value": "latest"
     }
   ],
   "labels": {

--- a/openshift/jenkins-persistent-template.json
+++ b/openshift/jenkins-persistent-template.json
@@ -265,7 +265,7 @@
       "name": "JENKINS_IMAGE",
       "displayName": "Jenkins docker image reference",
       "description": "Full name of jenkins image for example ",
-      "value": "wtrocki/jenkins"
+      "value": "aerogear/jenkins-1-centos7"
     },
     {
       "name": "JENKINS_IMAGE_VERSION",


### PR DESCRIPTION
## Motivation

Create Jenkins development base that would allow us to 
= add/edit/remove plugins
= change default configuration to the base image.
= remove openshift build pipelines spam jobs from image

## Notes 

Added plugin would be used to authenticate users in RHMAP platform - configuration for plugin would be added later. In this ticket we just wanted to show how to update/add new plugin so use this as example. 

## TODO 

Update dockerhub description once PR is merged.

## Verification

Template published to local machine and public openshift cluster. 
Use README.md for steps. 

ping @luigizuccarelli 