### PR TITLE
Update to allow for android-sdk-install (via jenkins job)

### DIFF
--- a/docker/android-slave/Dockerfile
+++ b/docker/android-slave/Dockerfile
@@ -34,25 +34,6 @@ RUN yum install -y git wget python curl expect expectk
 COPY tools /opt/tools
 ENV PATH ${PATH}:/opt/tools
 
-# Install Android SDK
-RUN cd /opt && wget --output-document=android-sdk.tgz --quiet https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz && \
-  tar xzf android-sdk.tgz && \
-  rm -f android-sdk.tgz
-
-RUN cd /opt && chown -R root.root android-sdk-linux && \
-  chmod -R 777 /opt/tools && \
-  /opt/tools/android-accept-licenses.sh "android-sdk-linux/tools/android update sdk --all --no-ui --filter platform-tools,tools" && \
-  /opt/tools/android-accept-licenses.sh "android-sdk-linux/tools/android update sdk --all --no-ui --filter platform-tools,tools,build-tools-25.0.0,android-25,addon-google_apis_x86-google-21,extra-android-support,extra-google-google_play_services,sys-img-armeabi-v7a-android-24"
-
-# Setup environment
-ENV ANDROID_HOME /opt/android-sdk-linux
-ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
-
-RUN which adb
-RUN which android
-
-RUN android list targets
-
 # GO to workspace
 RUN mkdir -p /opt/workspace
 WORKDIR /opt/workspace

--- a/docker/jenkins1-centos/Dockerfile
+++ b/docker/jenkins1-centos/Dockerfile
@@ -1,6 +1,14 @@
 FROM openshift/jenkins-1-centos7
 
+USER root
+
+# needed to wget the android sdk
+RUN yum install -y wget
+
 COPY ./contrib/kube-slave-common.sh /usr/local/bin/kube-slave-common.sh
 
 COPY plugins.txt /opt/openshift/configuration/plugins.txt
 RUN /usr/local/bin/plugins.sh /opt/openshift/configuration/plugins.txt
+
+# needed for gradlew 
+ENV JAVA_HOME=/etc/alternatives/java_sdk_1.8.0_openjdk

--- a/jenkinsfiles/install-android-sdk.sh
+++ b/jenkinsfiles/install-android-sdk.sh
@@ -1,0 +1,24 @@
+set -x
+
+BASE_DIR=/opt/tools
+ANDROID_SDK_DIR=/android-sdk-linux
+
+if [ -d "${BASE_DIR}/${ANDROID_SDK_DIR}" ]
+then
+  echo 'Android SDK installed continueing normally'
+else
+  echo 'Installing Android SDK'
+  cd ${BASE_DIR}
+  wget --output-document=android-sdk.tgz --quiet https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz
+  tar xzf android-sdk.tgz 
+  rm -f android-sdk.tg
+  
+  ( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | android-sdk-linux/tools/android update sdk --all --no-ui --filter platform-tools,tools
+  ( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | android-sdk-linux/tools/android update sdk --all --no-ui --filter platform-tools,tools,build-tools-25.0.0,android-25,addon-google_apis_x86-google-21,extra-android-support,extra-google-google_play_services,sys-img-armeabi-v7a-android-24
+
+  # Setup environment
+  export ANDROID_HOME=${BASE_DIR}/${ANDROID_SDK_DIR}
+  export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
+
+  android list target
+fi

--- a/jenkinsfiles/new-android.groovy
+++ b/jenkinsfiles/new-android.groovy
@@ -1,0 +1,32 @@
+node('android') {
+
+    stage('Checkout Source') {
+        dir('workspace') {
+            git "https://github.com/feedhenry/some-android-app"
+        }
+    }
+    
+    stage('Execute Gradle') {
+        dir('workspace') {
+            println(env.GRADLE_HOME)
+            def gradleHome = env.GRADLE_HOME
+            if (!gradleHome) {
+                // GRADLE_HOME=/var/lib/jenkins/android-sdk-linux/tools/templates/gradle/wrapper
+                println('GRADLE_HOME not set - please set it via Manage Jenkins -> Configure System -> Global properties -> Enviromental Variables - for the android node')
+                return -1
+            }
+            def proc = ["/bin/sh", "-c", "${gradleHome}/gradlew --version"].execute()
+            proc.waitFor()
+            println "stdout: ${proc.in.text}"
+            println "return code: ${ proc.exitValue()}"
+            println "stderr: ${proc.err.text}"
+            return proc.exitValue()
+        }
+    }
+
+    stage('Archive') {
+        dir('workspace') {
+            archive archive 'app/build/outputs/apk/*.apk'
+        }
+    }
+}

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -52,6 +52,32 @@ Note that `mkdir` and `chmod` commands above should be executed in the Docker-ma
 
     Login with the `admin` user name and password ${JENKINS_PASSWORD}.
 
+
+Jenkins Configuration
+---------------------
+
+The android-sdk is not 'included in any docker container' and therefore a simple 'freestyle job needs to be created' that will contain the scripts to download and install the android sdk
+
+1. Once logged into jenkins navigate to -> New Item
+
+        Click on the 'Freestyle project and enter 'install-android-sdk' as a jon name
+
+1. Navigate to 'Add build step' and click on 'Execute shell'
+
+        Copy and paste the script found in jenkinsfiles/install-android-sdk.sh
+
+1. Save 
+
+1. Navigate to 'Manage Jenkins' -> Configure system
+
+1. Click on Global properties and add the following (the slave uses this to execute gradlew)
+
+        In the field 'Name' enter GRADLE_HOME
+        In the field 'Value' enter /var/lib/jenkins/tools/templates/gradle/wrapper
+
+1. Save and execute the script 'install-android-sdk'
+
+
 Plugins
 ------
 


### PR DESCRIPTION
## Motivation:
The current android slave docker container has the android sdk 'baked' into the image
To avoid any legal problems with the license agreement it would be better to exclude the install and setup of the sdk in a container

##  Solution:
The best solution (and easiest - after days of trying plugins/master-slave configurations with external directory mounts etc) was found to be :-

  - Create a simple freestyle jenkins job
  - Copy the script (included in this repo jenkinsfiles/install-android-sdk.sh) into the job execute shell field
  - Add a Global variable GRADLE_HOME that points to the gradle wrapper directory
  - Create the android slave build pipeline with the script example (jenkinsfiles/new-android.groovy)
  - The install android job needs to be executed once only

Simple changes to the current dockerfile were necessary (set the JAVA_HOME env for gradle and include wget for the install script)

Result:
The slave relies on the GRADLE_HOME setting and calls the gradlew script.
This has been tested locally.

JIRA:
refer to AGDIGGER-43 for details and logs