### PR TITLE
Changed liveness probe timeout

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -19,12 +19,7 @@ If you already have persistent volumes feel free to skip this step.
 
         mkdir /tmp/jenkins
         chmod 777 /tmp/jenkins
-        # creating a cluster wide persistent volume like the one we use requires
-        # an admin user on OpenShift.
-        oc login -u system:admin
-        oc create -f ./sample-pv.json
-
-Note that `mkdir` and `chmod` commands above should be executed in the Docker-machine, in case of using Docker-machine (boot2docker) on Mac.
+        oc create -f ./sample-pv.json --as=system:admin
 
 1. Login as a normal user (any non-empty user name and password is fine)
 

--- a/openshift/jenkins-persistent-template.json
+++ b/openshift/jenkins-persistent-template.json
@@ -91,7 +91,7 @@
                 },
                 "livenessProbe": {
                     "timeoutSeconds": 3,
-                    "initialDelaySeconds": 120,
+                    "initialDelaySeconds": 720,
                     "httpGet": {
                         "path": "/login",
                         "port": 8080


### PR DESCRIPTION
## Definition of the problem

@aliok reported that none of the jenkins templates with PV work properly on on openshift instance created using `oc cluster up` command on mac with native docker machine.

## Solution

On some machines and environments (mac) and most likely slow internet connections jenkis startup is taking little bit longer than usual and pod is being killed automatically. When we give pod more time to run (4min at least) jenkins would start normally. Next subsequents starts with PV taking less than minute because all the configuration and plugins are downloaded and saved to the PV. I created issue and proposed fix for that directly in openshift repo so problem will be resolved in next release. 

## How to startup cluster

1) Startup cluster (would save data for next restarts):

```
oc cluster up --public-hostname '127.0.0.1' --host-data-dir '/Users/wtrocki/.oc/profiles/jenkins/data' --host-config-dir '/Users/wtrocki/.oc/profiles/jenkins/config' --routing-suffix '' --use-existing-config
```

2) Create PersistentVolume 
`oc create -f ./sample-pv.json --as=system:admin`

3) Check docker memory (just in case)
`cat $HOME/.docker/machine/machines/openshift/config.json | grep Memory`

8GB 👍 

4) Start template in default project (or any project you want)
`oc new-app -f ./jenkins-persistent-template.json`

5) Grab logs

 `oc logs jenkins-1-[tab]`

Pod logs finishing with:
`INFO: Started initialization`

Nothing happens for around 5 minutes depending on internet connection etc.

```
Dec 04, 2016 11:20:33 PM jenkins.InitReactorRunner$1 onAttained
INFO: Started initialization
Dec 04, 2016 11:26:05 PM jenkins.InitReactorRunner$1 onAttained
INFO: Listed all plugins
```

After that pod would start and jenkins should run properly. 
 
@aliok @matzew @luigizuccarelli @johnfriz - Added some useful hints for setting up new digger.
