### PR TITLE
Exclude unaligned apk binary in archivation step

### DIFF
--- a/jenkinsfiles/android_jenkinsfile.groovy
+++ b/jenkinsfiles/android_jenkinsfile.groovy
@@ -9,5 +9,5 @@ node('android') {
     sh "./gradlew clean assembleDebug"
 
     stage 'Archive'
-    archive 'app/build/outputs/apk/*.apk'
+    archiveArtifacts artifacts: 'app/build/outputs/apk/*.apk', excludes: 'app/build/outputs/apk/*-unaligned.apk'
 }


### PR DESCRIPTION
It is improbable that users will need *-unaligned.apk file, so we donẗ have to archive it on every build.