### PR TITLE
AGDIGGER-64 - enable master to slave security subsystem

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -15,7 +15,7 @@ S2I build is required in order to install new plugins and configuration
 Install s2i build tool from: https://github.com/openshift/source-to-image/releases/tag/v1.1.3
 Build openshift jenkins image with our modifications on your local machine
 
-    cd jenkins1-centos
+    cd jenkins2-centos
     docker build . -t aerogear/jenkins-2-centos7-s2i
 
 Execute s2i build command:
@@ -85,8 +85,8 @@ The following script is an example of downloading the sdk installation
 
     ```
     wget --output-document=android-sdk.tgz --quiet https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz
-    tar xzf android-sdk.tgz 
-    
+    tar xzf android-sdk.tgz
+
     android-sdk-linux/tools/android update sdk --all --no-ui --filter platform-tools,tools,build-tools-25.0.0,android-25,addon-google_apis_x86-google-21,extra-android-support,extra-google-google_play_services
 
     ```
@@ -95,7 +95,7 @@ This will build the final image with the android sdk version that was installed
 
     ```
     s2i build <directory-where-sdk-has-been-installed> docker.io/aerogear/android-sdk-sti aerogear/jenkins-android-slave:<version>
-    
+
     ```
 
 For release builds, publish the image to the openshift internal registry - please refer to this link for more info

--- a/docker/jenkins2-centos/Dockerfile
+++ b/docker/jenkins2-centos/Dockerfile
@@ -3,4 +3,8 @@ FROM openshift/jenkins-2-centos7
 COPY ./contrib/kube-slave-common.sh /usr/local/bin/kube-slave-common.sh
 
 COPY plugins.txt /opt/openshift/configuration/plugins.txt
-RUN /usr/local/bin/install-plugins.sh /opt/openshift/configuration/plugins.txt
+RUN /usr/local/bin/install-plugins.sh /opt/openshift/configuration/plugins.txt && \
+    mkdir $JENKINS_HOME/secrets && \
+    echo "false" > $JENKINS_HOME/secrets/slave-to-master-security-kill-switch && \
+    ## Prevent admins from changing master to slave security option
+    chmod 444 $JENKINS_HOME/secrets/slave-to-master-security-kill-switch

--- a/docker/jenkins2-centos/configuration/configuration.xml.tpl
+++ b/docker/jenkins2-centos/configuration/configuration.xml.tpl
@@ -2,8 +2,10 @@
 <hudson>
   <disabledAdministrativeMonitors/>
   <version>1.651</version>
-  <numExecutors>5</numExecutors>
-  <mode>NORMAL</mode>
+  <!-- Disabling master node -->
+  <label>disabled-node</label>
+  <numExecutors>0</numExecutors>
+  <mode>EXCLUSIVE</mode>
   <useSecurity>true</useSecurity>
   <authorizationStrategy class="hudson.security.GlobalMatrixAuthorizationStrategy">
     <permission>hudson.model.Computer.Configure:admin</permission>
@@ -50,7 +52,6 @@
   </views>
   <primaryView>All</primaryView>
   <slaveAgentPort>${JNLP_PORT}</slaveAgentPort>
-  <label>master</label>
   <nodeProperties/>
   <globalNodeProperties/>
   <noUsageStatistics>true</noUsageStatistics>


### PR DESCRIPTION
## Motivation

Enable by default master to slave security system and prevent admins from turning off this option.
Change was published to testing cluster. 

## Verification

Create job and trigger build. Example jenkinsfile:
https://github.com/wtrocki/helloworld-android-gradle/blob/test-security/Jenkinsfile

Review @josemigallas @odra @aliok 