### PR TITLE
Allow proxy setting as param for sdk download via HTTP proxy

### DIFF
--- a/openshift/android-sdk-persistent-template.json
+++ b/openshift/android-sdk-persistent-template.json
@@ -91,6 +91,10 @@
                   {
                     "name": "JAVA_HOME",
                     "value": "${JVM_HOME}"
+                  },
+                  {
+                    "name": "HTTPS_PROXY",
+                    "value": "${HTTPS_PROXY}"
                   }
                 ],
                 "resources": {
@@ -195,6 +199,12 @@
       "displayName": "Java HOME env var",
       "description": "Java HOME env var",
       "value": "/etc/alternatives/java_sdk_1.8.0"
+    },
+    {
+      "name": "HTTPS_PROXY",
+      "displayName": "Outbound proxy if required, used to download Android SDK",
+      "description": "HTTPS Proxy address, examples http://user:pass@10.10.10.10:8888, http://10.10.10.01:8888",
+      "value": ""
     }
   ],
   "labels": {


### PR DESCRIPTION
If the container is running in an environment with a HTTP proxy configured, we would not be able to download via the Python request module. The module respects environment variables, so allowing this to be passed as a param and set as an env var allows the download in this case