### PR TITLE
Fix folder structure during OSX node creation

### DIFF
--- a/docker/jenkins2-centos/contrib/jenkins/create-osx-node.sh
+++ b/docker/jenkins2-centos/contrib/jenkins/create-osx-node.sh
@@ -3,7 +3,7 @@
 if [ ! -z "${OSX_SLAVE_HOST}" ]; then
     echo "Copying Jenkins OSX node configuration to ${JENKINS_HOME}/nodes ..."
     mkdir -p ${image_config_dir}
-    cp -r ${image_config_dir}/nodes ${JENKINS_HOME}/nodes
+    cp -r ${image_config_dir}/nodes/* ${JENKINS_HOME}/nodes
     rm -rf ${image_config_dir}/nodes
 
     envsubst < "${JENKINS_HOME}/nodes/digger-ios/config.xml.tpl" > "${JENKINS_HOME}/nodes/digger-ios/config.xml"


### PR DESCRIPTION
In previous version it produced this folder structure:
> /var/lib/jenkins/nodes/nodes/digger-ios

but expected structure is:

> /var/lib/jenkins/nodes/digger-ios