### PR TITLE
Change OSX node label to "ios"

### DIFF
--- a/docker/jenkins2-centos/configuration/nodes/digger-ios/config.xml.tpl
+++ b/docker/jenkins2-centos/configuration/nodes/digger-ios/config.xml.tpl
@@ -13,6 +13,6 @@
         <maxNumRetries>0</maxNumRetries>
         <retryWaitTime>0</retryWaitTime>
     </launcher>
-    <label>macOS</label>
+    <label>ios</label>
     <nodeProperties/>
 </slave>


### PR DESCRIPTION
I think "ios" label better describes purpose of the node.