### PR TITLE
readwritemany access mode

### DIFF
--- a/openshift/android-sdk-sample-pv.json
+++ b/openshift/android-sdk-sample-pv.json
@@ -9,7 +9,7 @@
       "storage": "10Gi"
     },
     "accessModes": [
-      "ReadWriteOnce"
+      "ReadWriteMany"
     ],
     "persistentVolumeReclaimPolicy": "Recycle",
     "hostPath": {


### PR DESCRIPTION
@odra @PhilipGough 
As we want to allow the Android Sdk PV to be access by more than one pod (i.e. multiple slaves) which could possibly be scheduled to different nodes.
we should use the readwritemany access policy. 
As per [the openshift docs](https://docs.openshift.com/container-platform/latest/architecture/additional_concepts/storage.html#pv-access-modes)