### PR TITLE
Expect script

### DIFF
--- a/docker/android-sdk/Dockerfile
+++ b/docker/android-sdk/Dockerfile
@@ -21,7 +21,8 @@ RUN yum install -y \
   java-1.8.0-openjdk \
   ant \
   which\
-  wget
+  wget \
+  expect
 
 #install dependencies and links androidctl cli to /usr/bin
 RUN curl 'https://bootstrap.pypa.io/get-pip.py' -o 'get-pip.py' && \

--- a/docker/android-sdk/tools/androidctl-bin
+++ b/docker/android-sdk/tools/androidctl-bin
@@ -1,5 +1,17 @@
 #!/bin/bash
 
 DIR=$(dirname "$(readlink -f "$0")")
+CMD="python $DIR/androidctl $@"
 
-python "$DIR/androidctl" "$@"
+if [ -z "$ANSWER" ]; then
+  ANSWER='n'
+fi
+
+expect -c "
+set timeout -1;
+spawn $CMD
+expect {
+    \"Accept? (y/N):\" { exp_send \"$ANSWER\r\" ; exp_continue }
+    eof
+}
+"

--- a/docker/android-sdk/tools/androidctl-bin
+++ b/docker/android-sdk/tools/androidctl-bin
@@ -1,11 +1,20 @@
 #!/bin/bash
 
 DIR=$(dirname "$(readlink -f "$0")")
-CMD="python $DIR/androidctl $@"
+#CMD="python $DIR/androidctl $@"
+
+getopts ":y" _ANSWER
+
+if [ "$_ANSWER" != "?" ]; then
+  ANSWER='y'
+  shift
+fi
 
 if [ -z "$ANSWER" ]; then
   ANSWER='n'
 fi
+
+CMD="python $DIR/androidctl $@"
 
 expect -c "
 set timeout -1;


### PR DESCRIPTION
# Changes
* adds expect script in android-sdk container;
* modifies androidctl-bin to use expect script to accept android license based on `ANSWER` parameter.

# Usage

`ANSWER=y androidctl sync /opt/tools/sample.cfg #accepts license`
`ANSWER=n androidctl sync /opt/tools/sample.cfg #does not accept license`
`androidctl sync /opt/tools/sample.cfg #"n" is used as default value if ANSWER var is not set`

The image was pushed to dockerhub as `aerogear/android-sdk:dev`

ping @laurafitzgerald 