### PR TITLE
added shell parameter for sdkmanager

### DIFF
--- a/docker/android-sdk/tools/androidctl-bin
+++ b/docker/android-sdk/tools/androidctl-bin
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 DIR=$(dirname "$(readlink -f "$0")")
-#CMD="python $DIR/androidctl $@"
 
 getopts ":y" _ANSWER
 

--- a/docker/android-sdk/tools/androidctl-bin
+++ b/docker/android-sdk/tools/androidctl-bin
@@ -19,7 +19,13 @@ expect -c "
 set timeout -1;
 spawn $CMD
 expect {
-    \"Accept? (y/N):\" { exp_send \"$ANSWER\r\" ; exp_continue }
+    \"Accept? (y/N):\" { 
+      exp_send \"$ANSWER\r\";
+      if {$ANSWER eq \"y\"} {
+        exp_send \"Android SDK license accepted, resuming installation process...\n\";
+      }
+      exp_continue;
+    }
     eof
 }
 "

--- a/docker/android-sdk/tools/androidctl/props.cfg
+++ b/docker/android-sdk/tools/androidctl/props.cfg
@@ -1,6 +1,7 @@
 [sdk]
 path = /opt/android-sdk-linux
 url = https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip
+shell = /bin/bash
 
 [keytool]
 name = android.debug

--- a/docker/android-sdk/tools/androidctl/props.py
+++ b/docker/android-sdk/tools/androidctl/props.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 
 _cwd = os.path.dirname(os.path.realpath(__file__))
 config = None
-SDK = namedtuple('Properties', ['path', 'url'])
+SDK = namedtuple('Properties', ['path', 'url', 'shell'])
 KeyTool = namedtuple('KeyTool', ['name', 'params'])
 sdk = None
 keytool = None

--- a/docker/android-sdk/tools/androidctl/sdk.py
+++ b/docker/android-sdk/tools/androidctl/sdk.py
@@ -12,11 +12,14 @@ import props
 
 sdk_path = os.environ.get('ANDROID_HOME', props.sdk.path)
 sdk_url = props.sdk.url
+sdk_shell = props.sdk.shell
 https_proxy = os.environ.get('HTTPS_PROXY')
+
 
 def manager(*args):
   cmd = '%s/tools/bin/sdkmanager' % sdk_path
   cmd_args = [
+    sdk_shell,
     cmd
   ]
   proxy_settings = getProxySettings(https_proxy)


### PR DESCRIPTION
uses `/bin/bash` as bash interpreter when running `sdkmanager` command since `/bin/sh` can raise a permission problem inside the container

Docker image pushed as `aerogear/android-sdk:dev`.