### PR TITLE
update keystore type to jks

### DIFF
--- a/jenkinsfiles/build.json
+++ b/jenkinsfiles/build.json
@@ -3,9 +3,9 @@
         "debug": {
             "keystore": "/opt/android-sdk-linux/android.debug",
             "storePassword": "android",
-            "alias": "android",
+            "alias": "dummyalias",
             "password" : "android",
-            "keystoreType": "android"
+            "keystoreType": "jks"
         }
     }
 }


### PR DESCRIPTION
**JIRA**
https://issues.jboss.org/browse/RHMAP-15733

update keystore type to fix error

**Verification steps**
Build the android app using the cordova Jenkinsfile and updated build.json
Project available [here](https://osm4-rhmap.osm4.skunkhenry.com/#projects/7lxbuli4pxaf6hi67xmhwrzp/apps/7lxbulntw6jcw3y77aar6qnz/build)