### PR TITLE
Add OSX user to sudoers list

### DIFF
--- a/admin/create-osx-user.sh
+++ b/admin/create-osx-user.sh
@@ -28,7 +28,7 @@ GROUP_ID=20
 ############### end of parameters
 ###############
 
-echo "IMPORTANT: this script will now create user ${USERNAME} with password ${PASSWORD}."
+echo "IMPORTANT: this script will now create user ${USERNAME} with password ${PASSWORD} and add him to sudoers list."
 echo "Your machine will be accessible with SSH using these credentials."
 
 . /etc/rc.common
@@ -43,5 +43,6 @@ dscl . create /Users/${USERNAME} NFSHomeDirectory /Users/${USERNAME}
 cp -R /System/Library/User\ Template/English.lproj /Users/${USERNAME}
 chown -R ${USERNAME}:${GROUP_NAME} /Users/${USERNAME}
 
+echo "${USERNAME}  ALL=(ALL:ALL) ALL" >> /etc/sudoers
 
 echo "Done creating OSX user."


### PR DESCRIPTION
To perform machine configuration we need to elevate privileges, that's why newly created user needs to be added to sudoers list.

JIRA: https://issues.jboss.org/browse/AGDIGGER-142